### PR TITLE
Rickshaw.json new prototype format

### DIFF
--- a/rickshaw.json
+++ b/rickshaw.json
@@ -1,26 +1,285 @@
 {
-    "rickshaw-benchmark": {
-        "schema": {
-            "version": "2020.05.18"
-        }
-    },
-    "benchmark": "fio",
-    "controller" : {
-        "pre-script" : "%bench-dir%/fio-prepare-jobfile",
-        "post-script" : "%bench-dir%fio-post-process"
-    },
-    "client" : {
-        "files-from-controller": [
-            { "src": "%run-dir%/fio.job", "dest": "." },
-            { "src": "%bench-dir%/fio-get-runtime", "dest": "/usr/bin/" }
-        ],
-        "runtime" : "fio-get-runtime",
-        "start" : "fio",
-        "param_regex" : [ "s/--clients=.+//",
-			  "s/\\s--jobfile=(\\S+)//",
-			  "s/(.*)/$1 fio.job/",
-			  "s/(\\s--[^\\s]+)=ON/$1/g",
-			  "s/\\s--[^\\s]+=OFF//g"
-			]
+  "rickshaw-benchmark": {
+    "schema": {
+      "version": "2020.11.04"
     }
+  },
+  "benchmark": "fio",
+  "controller": {
+    "pre-script": "%bench-dir%/fio-prepare-jobfile",
+    "post-script": "%bench-dir%fio-post-process"
+  },
+  "client": {
+    "files-from-controller": [
+      {
+        "src": "%run-dir%/fio.job",
+        "dest": "."
+      },
+      {
+        "src": "%bench-dir%/fio-get-runtime",
+        "dest": "/usr/bin/"
+      }
+    ],
+    "runtime": "fio-get-runtime",
+    "start": "fio",
+    "param_regex": [
+      "s/--clients=.+//",
+      "s/\\s--jobfile=(\\S+)//",
+      "s/(.*)/$1 fio.job/"
+    ]
+  },
+  "params": {
+    "mandatory": [
+      {
+        "arg": "write_hist_log",
+        "val": "fio"
+      },
+      {
+        "arg": "log_hist_msec",
+        "val": "10000"
+      },
+      {
+        "arg": "write_bw_log",
+        "val": "fio"
+      },
+      {
+        "arg": "write_iops_log",
+        "val": "fio"
+      },
+      {
+        "arg": "write_lat_log",
+        "val": "fio"
+      },
+      {
+        "arg": "log_avg_msec",
+        "val": "1000"
+      },
+      {
+        "arg": "log_unix_epoch",
+        "val": "1"
+      },
+      {
+        "arg": "output-format",
+        "val": "json"
+      },
+      {
+        "arg": "output",
+        "val": "fio-result.json"
+      }
+    ],
+    "requirements": [
+      { "name": "size_KMG",
+        "description": "bytes in k/K (1024), m/M (1024^2) or g/G (1024^3): 4k 16M 1g",
+        "args": [
+          "bs",
+          "filesize",
+          "io_size",
+          "mem"
+        ],
+        "val_regex": "[0-9]+[kbmgKBMG]",
+        "val_transforms": [
+          "s/([0-9]+)[gG]/($1*1024).\"M\"/e",
+          "s/([0-9]+)[mM]/($1*1024).\"K\"/e"
+        ]
+      },
+      { "name": "size_KMG_range",
+        "description": "a range of size_KMG: 4k-8k 16k-2m 24m-1G",
+        "args": [
+          "bsrange",
+          "bssplit"
+        ],
+        "val_regex": "[0-9]+[kbmgKBMG]\\-[0-9]+[kbmgKBMG]",
+        "val_transforms": [
+          "s/([0-9]+)[gG]/($1*1024).\"M\"/eg",
+          "s/([0-9]+)[mM]/($1*1024).\"K\"/eg"
+        ]
+      },
+      { "name": "generic_string",
+        "description": "all types of strings",
+        "args": [
+          "output-format",
+          "output",
+          "buffer_pattern",
+          "cgroup",
+          "clocksource",
+          "continue_on_error",
+          "cpus_allowed_policy",
+          "cpus_allowed",
+          "directory",
+          "exec_postrun",
+          "exec_prerun",
+          "filename",
+          "ignore_error",
+          "ioscheduler",
+          "jobfile"
+        ],
+        "val_regex": ".+"
+      },
+      { "name": "rw_types",
+        "description": "all possible testtypes",
+        "args": [
+          "rw"
+        ],
+        "val_regex": "^(|rand)(read|write|trim)$|^readwrite$|^randrw$|^trimwrite$"
+      },
+      { "name": "ioengine_types",
+        "description": "all possible ioengine types",
+        "args": [
+          "ioengine"
+        ],
+        "val_regex": "^(|p|pv|v)sync$|^pvsync2$|^posixaio$|^mmap$|^(|net)splice$|^sg$|^null$|^net$|^cpuio$|^rdma$|^e4defrag$|^falloc$|^filecreate$|^external$|^libaio$"
+      },
+      { "name": "log_types",
+        "description": "all possible log types",
+        "args": [
+          "write_bw_log",
+          "write_hist_log",
+          "write_iolog",
+          "write_iops_log",
+          "write_lat_log"
+        ],
+        "val_regex": "^fio$"
+      },
+      { "name": "io_submit_modes",
+        "description": "How IO submissions and completions are done",
+        "args": [
+          "io_submit_mode"
+        ],
+        "val_regex": "^inline$|^offload$"
+      },
+      { "name": "time_smh",
+        "description": "time in seconds, minutes, or hours: 10s 2m 1h",
+        "args": [
+          "runtime",
+          "steadystate_duration",
+          "steadystate_ramp_time",
+          "steadystate"
+        ],
+        "val_regex": "^[0-9]+[smh]$"
+      },
+      { "name": "boolean",
+        "description": "1 for true and 0 for false",
+        "args": [
+          "allow_file_create",
+          "allow_mounted_write",
+          "allrandrepeat",
+          "atomic",
+          "block_error_percentiles",
+          "buffered",
+          "cgroup_nodelete",
+          "clat_percentiles",
+          "create_fsync",
+          "create_only",
+          "create_on_open",
+          "create_serialize",
+          "direct",
+          "disable_bw_measurement",
+          "disable_clat",
+          "disable_lat",
+          "disable_slat",
+          "disk_util",
+          "do_verify",
+          "end_fsync",
+          "error_dump",
+          "experimental_verify",
+          "file_append",
+          "fill_device",
+          "fsync_on_close",
+          "gtod_reduce",
+          "invalidate",
+          "lat_percentiles",
+          "log_max_val",
+          "log_offset",
+          "log_store_compressed",
+          "log_unix_epoch",
+          "overwrite",
+          "per_job_logs",
+          "pre_read",
+          "randrepeat",
+          "rate_ignore_thinktime",
+          "replay_no_stall",
+          "scramble_buffers",
+          "serialize_overlap",
+          "stats",
+          "sync",
+          "trim_verify_zero",
+          "unified_rw_reporting",
+          "unique_filename",
+          "unlink_each_loop",
+          "unlink",
+          "verify_dump",
+          "erify_fatal",
+          "verify_state_load",
+          "verify_state_save",
+          "time_based"
+        ],
+        "val_regex": "[0,1]"
+      },
+      { "name": "positive_integer",
+        "description": "a whole number greater than 0",
+        "args": [
+          "ba",
+          "buffer_compress_chunk",
+          "buffer_compress_percentage",
+          "bwavgtime",
+          "cgroup_weight",
+          "cpumask",
+          "dedupe_percentage",
+          "fdatasync",
+          "flow_id",
+          "flow_sleep",
+          "flow",
+          "flow_watermark",
+          "fsync",
+          "gia",
+          "gtod_cpu",
+          "hugepage-size",
+          "iodepth_batch_complete_max",
+          "iodepth_batch_complete_min",
+          "iodepth_batch",
+          "iodepth_low",
+          "iodepth",
+          "iopsavgtime",
+          "kb_base",
+          "log_avg_msec",
+          "log_compression",
+          "log_hist_coarseness",
+          "log_hist_msec",
+          "loops",
+          "nice",
+          "nrfiles",
+          "numjobs",
+          "offset_align",
+          "openfiles",
+          "percentage_random",
+          "prioclass",
+          "prio",
+          "rate_cycle",
+          "rate_iops_min",
+          "rate_iops",
+          "rate_min",
+          "rate",
+          "replay_align",
+          "replay_scale",
+          "replay_time_scale",
+          "rwmixread",
+          "rwmixwrite",
+          "significant_figures",
+          "thinktime_blocks",
+          "thinktime_spin",
+          "thinktime",
+          "trim_backlog_batch",
+          "trim_percentage",
+          "uid",
+          "unit_base",
+          "verify_async",
+          "verify_backlog_batch",
+          "verify_interval",
+          "verify_offset",
+          "write_barrier"
+        ],
+        "val_regex": "[1-9][0-9]*"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
-Includes a list of mandatory requirements
 -When rickshaw runs this benchmark, if the mandatory reqs are missing, they will be added
-Includes a list of param requirements
 -Rickshaw will match each arg of the user-provided params (bench-params.json) to a
  a requirement that has a matching arg string, then validate the value from the
  user-provided param passes the val_regex.  If there is a val_transforms, they are
  applied to the value.
-All of the rickshaw work still needs to be done
-The schema for rickshaw.json will need to be updated
-"defaults" is not included here.  Defaults was a multi-val param-set once used in
 multiplex subproject.  That functionality will be added to the new mulituplex
 utility.

in this list and confirm the params's value is valid