### PR TITLE
fio-prepare-jobfile: allow the user to request a blank jobfile

### DIFF
--- a/fio-prepare-jobfile
+++ b/fio-prepare-jobfile
@@ -18,6 +18,8 @@ done
 if [ -z "$jobfile_path" ]; then
 	echo [global] >fio.job
 	echo [job-1] >>fio.job
+elif [ "$jobfile_path" == "EMPTY_JOB_FILE" ]; then
+	echo >fio.job
 elif [ ! -e $jobfile_path ]; then
 	echo "could not find [$jobfile_path]"
 	exit 1


### PR DESCRIPTION
- It is possible for even the minimally populated job file to conflict
  with the command line parameters so allow the user to request an
  empty jobfile that will not interact with the command line at all.

- The alternative would be to use no job file at all, but the
  mechanics of integrating that would be troublesome given the how
  rickshaw.json is currently constructed (things like the param_regex
  cannot be applied conditionally).