### PR TITLE
update zlib from 1.2.11 to 1.2.12

### DIFF
--- a/workshop.json
+++ b/workshop.json
@@ -81,7 +81,7 @@
             "name": "zlib_src",
             "type": "source",
             "source_info": {
-                "url": "https://www.zlib.net/zlib-1.2.11.tar.gz",
+                "url": "https://www.zlib.net/zlib-1.2.12.tar.gz",
                 "filename": "zlib.tar.gz",
                 "commands": {
                     "unpack": "tar -xzf zlib.tar.gz",


### PR DESCRIPTION
- zlib.net removed zlib 1.2.11 from this download location when 1.2.12
  was released