### PR TITLE
update fio build to disable optimizations to ensure cross-processor c…

### DIFF
--- a/workshop.json
+++ b/workshop.json
@@ -105,7 +105,7 @@
                     "unpack": "tar -xzf fio.tar.gz",
                     "get_dir": "tar -tzf fio.tar.gz | head -n 1",
                     "commands": [
-                        "./configure",
+                        "./configure --disable-optimizations",
                         "make",
                         "make install",
                         "fio --version"
@@ -123,7 +123,7 @@
                     "unpack": "tar -xzf fio.tar.gz",
                     "get_dir": "tar -tzf fio.tar.gz | head -n 1",
                     "commands": [
-                        "./configure",
+                        "./configure --disable-optimizations",
                         "make",
                         "make install",
                         "fio --version"


### PR DESCRIPTION
…ompatbility

- when sharing binaries across different processor revisions using the "native" optimizations can lead to segmentation faults when binaries are generated with instructions that are not supported on other (older) processors

- Linux distributions have to make similar decisions on what hardware they want to support with the binaries that they build and deploy; looking at the Fedora 36 fio source package they use the --disable-optimizations option to ensure compatability.