### PR TITLE
Fix zlib src url, pin to version 1.2

### DIFF
--- a/workshop.json
+++ b/workshop.json
@@ -81,7 +81,7 @@
             "name": "zlib_src",
             "type": "source",
             "source_info": {
-                "url": "https://www.zlib.net/zlib-1.2.13.tar.gz",
+                "url": "https://www.zlib.net/fossils/zlib-1.2.13.tar.gz",
                 "filename": "zlib.tar.gz",
                 "commands": {
                     "unpack": "tar -xzf zlib.tar.gz",


### PR DESCRIPTION
zlib latest is now 1.3, pinning to 1.2.

Permalink for the most recent release:
https://www.zlib.net/current/zlib.tar.gz

Older releases moved to https://www.zlib.net/fossils/